### PR TITLE
Adding user stroke options

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ You can start the quiz by calling `writer.quiz.start()`.
 
 - To listen for state changes (such as the current stroke index, or whether the quiz is active), use `writer.quiz.useStore(selector)`
 - To listen for specific quiz events (such as completed, correct stroke, mistakes), attach them as arguments to `writer.quiz.start()`.
+- To change the user stroke style you can optionally pass `userStrokeStyle={{ strokeColor: 'blue', strokeWidth: 10, strokeLinecap: 'round', strokeLinejoin: 'round' }}` to `<HanziWriter>`
 
 ```tsx
 import { HanziWriter, useHanziWriter } from '@jamsch/react-native-hanzi-writer';


### PR DESCRIPTION
I would like to add the option to pass styles (color, width, linecap, linejoin) for the <Path> elements drawn by the user in Quiz mode. I decided to extend the HanziWriterContext with an optional object "userStrokeStyle". It can be used like this:
`<HanziWriter writer={writer} userStrokeStyle={{ strokeColor: 'blue', strokeWidth: 10, strokeLinecap: 'round', strokeLinejoin: 'round' }}>...</HanziWriter>` 
Thanks for this great library!